### PR TITLE
Fix local stack keycloak login

### DIFF
--- a/scripts/local-stack-up.sh
+++ b/scripts/local-stack-up.sh
@@ -8,6 +8,32 @@ APP_COMPOSE=(docker compose -f .devcontainer/docker-compose.yml)
 STACK_COMPOSE=(docker compose -f thunderbird-accounts/docker-compose.yml)
 STACK_SERVICES=(kcpostgres keycloak stalwart)
 
+ensure_keycloak_theme_static() {
+  local static_dir="thunderbird-accounts/keycloak/themes/tbpro/static"
+  local image_id=""
+  local container_id=""
+
+  echo "[local-stack] ensuring local Keycloak theme static assets"
+  "${STACK_COMPOSE[@]}" build keycloak
+  image_id="$("${STACK_COMPOSE[@]}" images -q keycloak)"
+  if [[ -z "$image_id" ]] || ! docker image inspect "$image_id" >/dev/null 2>&1; then
+    image_id="thunderbird-accounts-keycloak:latest"
+  fi
+  if ! docker image inspect "$image_id" >/dev/null 2>&1; then
+    echo "[local-stack] could not resolve built Keycloak image" >&2
+    exit 1
+  fi
+
+  mkdir -p "$static_dir"
+  container_id="$(docker create "$image_id")"
+  if ! docker cp "$container_id:/opt/keycloak/themes/tbpro/static/." "$static_dir/"; then
+    docker rm "$container_id" >/dev/null
+    echo "[local-stack] failed to copy Keycloak theme static assets" >&2
+    exit 1
+  fi
+  docker rm "$container_id" >/dev/null
+}
+
 if [[ "${WITH_ACCOUNTS:-}" == "1" || "${WITH_ACCOUNTS:-}" == "true" ]]; then
   STACK_SERVICES=(postgres redis accounts mailpit "${STACK_SERVICES[@]}")
 fi
@@ -25,6 +51,8 @@ if [[ ! -f "$stalwart_config" ]] \
     sudo cp thunderbird-accounts/config.toml.example "$stalwart_config"
   fi
 fi
+
+ensure_keycloak_theme_static
 
 echo "[local-stack] starting local auth and mail services"
 "${STACK_COMPOSE[@]}" up --build -d "${STACK_SERVICES[@]}"

--- a/tests/unit/infra/vite-local-stack.test.ts
+++ b/tests/unit/infra/vite-local-stack.test.ts
@@ -1,0 +1,132 @@
+import { EventEmitter } from 'node:events';
+import zlib from 'node:zlib';
+
+import {
+  describe, expect, it, vi,
+} from 'vitest';
+
+import {
+  bufferAndRewriteResponse,
+  keycloakDevProxy,
+  shouldRewriteKeycloakBody,
+} from '../../../vite.local-stack.mjs';
+
+function bufferedResponse({
+  body,
+  headers,
+  rewriteBody = false,
+  rewriteBodyFn,
+  statusCode = 200,
+}) {
+  return new Promise((resolve) => {
+    const proxyRes = new EventEmitter();
+    proxyRes.headers = headers;
+    proxyRes.statusCode = statusCode;
+
+    const res = {
+      writeHead(status, writtenHeaders) {
+        this.status = status;
+        this.headers = writtenHeaders;
+      },
+      end(writtenBody) {
+        resolve({
+          body: Buffer.from(writtenBody),
+          headers: this.headers,
+          status: this.status,
+        });
+      },
+    };
+
+    bufferAndRewriteResponse(proxyRes, { url: '/test' }, res, {
+      rewriteBody,
+      rewriteBodyFn,
+    });
+
+    proxyRes.emit('data', body);
+    proxyRes.emit('end');
+  });
+}
+
+describe('local-stack Keycloak dev proxy', () => {
+  it('requests identity encoding from Keycloak', () => {
+    const proxy = new EventEmitter();
+    const config = keycloakDevProxy('http://keycloak:8999');
+
+    config.configure(proxy);
+
+    const proxyReq = { setHeader: vi.fn() };
+    proxy.emit('proxyReq', proxyReq);
+
+    expect(config.headers['Accept-Encoding']).toBe('identity');
+    expect(proxyReq.setHeader).toHaveBeenCalledWith('Accept-Encoding', 'identity');
+  });
+
+  it('does not rewrite static JavaScript resources', () => {
+    expect(shouldRewriteKeycloakBody(
+      { url: '/resources/abc/login/tbpro/static/app.js' },
+      { headers: { 'content-type': 'application/javascript' } },
+    )).toBe(false);
+
+    expect(shouldRewriteKeycloakBody(
+      { url: '/resources/abc/login/tbpro/static/app.css' },
+      { headers: { 'content-type': 'text/css' } },
+    )).toBe(false);
+  });
+
+  it('rewrites OIDC JSON and HTML pages', () => {
+    expect(shouldRewriteKeycloakBody(
+      { url: '/realms/tbpro/.well-known/openid-configuration' },
+      { headers: { 'content-type': 'application/json' } },
+    )).toBe(true);
+
+    expect(shouldRewriteKeycloakBody(
+      { url: '/realms/tbpro/protocol/openid-connect/auth' },
+      { headers: { 'content-type': 'text/html; charset=utf-8' } },
+    )).toBe(true);
+  });
+});
+
+describe('bufferAndRewriteResponse', () => {
+  it('decodes compressed rewritten responses and drops stale body headers', async () => {
+    const upstreamBody = Buffer.from('{"issuer":"http://keycloak:8999/realms/tbpro"}');
+    const gzipped = zlib.gzipSync(upstreamBody);
+
+    const result = await bufferedResponse({
+      body: gzipped,
+      headers: {
+        'content-encoding': 'gzip',
+        'content-length': String(gzipped.length),
+        'content-type': 'application/json',
+        etag: '"stale"',
+      },
+      rewriteBody: true,
+      rewriteBodyFn: (body) => body.replaceAll('http://keycloak:8999', 'https://localhost:3000'),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.headers['content-encoding']).toBeUndefined();
+    expect(result.headers.etag).toBeUndefined();
+    expect(result.headers['content-length']).toBe(String(result.body.length));
+    expect(result.body.toString('utf8')).toBe('{"issuer":"https://localhost:3000/realms/tbpro"}');
+  });
+
+  it('passes compressed static resources through unchanged when not rewriting', async () => {
+    const upstreamBody = Buffer.from('console.log("tbpro theme");');
+    const gzipped = zlib.gzipSync(upstreamBody);
+
+    const result = await bufferedResponse({
+      body: gzipped,
+      headers: {
+        'content-encoding': 'gzip',
+        'content-length': String(gzipped.length),
+        'content-type': 'application/javascript',
+      },
+      rewriteBody: false,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.headers['content-encoding']).toBe('gzip');
+    expect(result.headers['content-length']).toBe(String(gzipped.length));
+    expect(result.body.equals(gzipped)).toBe(true);
+  });
+});

--- a/vite.local-stack.mjs
+++ b/vite.local-stack.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import http from "node:http";
+import zlib from "node:zlib";
 
 /**
  * Vite dev-server proxies for LOCAL_STACK=1.
@@ -65,24 +66,80 @@ function stripHopByHopHeaders(headers) {
   return next;
 }
 
-function bufferAndRewriteResponse(proxyRes, req, res, { rewriteBody = false, rewriteBodyFn, rewriteHeadersFn } = {}) {
+function stripStaleBodyHeaders(headers) {
+  delete headers["content-encoding"];
+  delete headers["content-md5"];
+  delete headers["digest"];
+  delete headers.etag;
+}
+
+function contentEncoding(headers) {
+  return String(headers["content-encoding"] ?? "").trim().toLowerCase();
+}
+
+function decodeBody(body, encoding) {
+  switch (encoding) {
+    case "":
+    case "identity":
+      return Promise.resolve(body);
+    case "br":
+      return new Promise((resolve, reject) => {
+        zlib.brotliDecompress(body, (err, decoded) => (err ? reject(err) : resolve(decoded)));
+      });
+    case "deflate":
+      return new Promise((resolve, reject) => {
+        zlib.inflate(body, (err, decoded) => (err ? reject(err) : resolve(decoded)));
+      });
+    case "gzip":
+    case "x-gzip":
+      return new Promise((resolve, reject) => {
+        zlib.gunzip(body, (err, decoded) => (err ? reject(err) : resolve(decoded)));
+      });
+    default:
+      return Promise.reject(new Error(`Unsupported proxied response encoding: ${encoding}`));
+  }
+}
+
+export function shouldRewriteKeycloakBody(req, proxyRes) {
+  const contentType = String(proxyRes.headers["content-type"] ?? "");
+  return Boolean(
+    req.url?.includes(".well-known/openid-configuration")
+      || contentType.includes("json")
+      || contentType.includes("html"),
+  );
+}
+
+export function bufferAndRewriteResponse(proxyRes, req, res, { rewriteBody = false, rewriteBodyFn, rewriteHeadersFn } = {}) {
   const chunks = [];
   proxyRes.on("data", (chunk) => chunks.push(chunk));
-  proxyRes.on("end", () => {
+  proxyRes.on("end", async () => {
     let body = Buffer.concat(chunks);
     const rewrittenHeaders = rewriteHeadersFn ? rewriteHeadersFn(proxyRes.headers) : proxyRes.headers;
     const headers = stripHopByHopHeaders(rewrittenHeaders);
     delete headers["content-length"];
 
-    if (rewriteBody) {
-      const text = body.toString("utf8");
-      const rewritten = rewriteBodyFn ? rewriteBodyFn(text) : text;
-      body = Buffer.from(rewritten, "utf8");
-    }
+    try {
+      if (rewriteBody) {
+        body = await decodeBody(body, contentEncoding(headers));
+        stripStaleBodyHeaders(headers);
 
-    headers["content-length"] = String(body.length);
-    res.writeHead(proxyRes.statusCode ?? 502, headers);
-    res.end(body);
+        const text = body.toString("utf8");
+        const rewritten = rewriteBodyFn ? rewriteBodyFn(text) : text;
+        body = Buffer.from(rewritten, "utf8");
+      }
+
+      headers["content-length"] = String(body.length);
+      res.writeHead(proxyRes.statusCode ?? 502, headers);
+      res.end(body);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const errorBody = Buffer.from(`Proxy response rewrite failed: ${message}`, "utf8");
+      res.writeHead(502, {
+        "content-length": String(errorBody.length),
+        "content-type": "text/plain; charset=utf-8",
+      });
+      res.end(errorBody);
+    }
   });
 }
 
@@ -93,18 +150,17 @@ export function keycloakDevProxy(target) {
     secure: false,
     selfHandleResponse: true,
     headers: {
+      "Accept-Encoding": "identity",
       "X-Forwarded-Proto": "https",
       "X-Forwarded-Host": "localhost:3000",
       "X-Forwarded-Port": "3000",
     },
     configure(proxy) {
+      proxy.on("proxyReq", (proxyReq) => {
+        proxyReq.setHeader("Accept-Encoding", "identity");
+      });
       proxy.on("proxyRes", (proxyRes, req, res) => {
-        const ct = String(proxyRes.headers["content-type"] ?? "");
-        const shouldRewrite =
-          req.url?.includes(".well-known/openid-configuration")
-          || ct.includes("json")
-          || ct.includes("html")
-          || ct.includes("javascript");
+        const shouldRewrite = shouldRewriteKeycloakBody(req, proxyRes);
         bufferAndRewriteResponse(proxyRes, req, res, {
           rewriteBody: shouldRewrite,
           rewriteBodyFn: rewriteKeycloakBody,


### PR DESCRIPTION
## What changed?

Fixed local-stack Keycloak login theme loading in Firefox. After clicking “Sign in with Thunderbird”, the Keycloak login page rendered only fallback language controls and Firefox reported `NS_ERROR_CORRUPTED_CONTENT` for proxied theme assets such as `/resources/.../login/tbpro/static/app.css`.

- Updated `scripts/local-stack-up.sh` to build the local Keycloak image and copy the generated `tbpro/static` theme assets into the ignored bind-mounted submodule directory before starting the stack.
- Hardened `vite.local-stack.mjs` so rewritten proxy responses decode compressed bodies first and drop stale body headers such as `content-encoding`, `content-length`, and `etag`.
- Narrowed Keycloak body rewriting to OIDC JSON and HTML responses, leaving static CSS/JS resources as pass-through assets.
- Added unit coverage for Keycloak proxy identity encoding, rewrite selection, compressed rewritten responses, and static CSS/JS pass-through.

Patch written by Codex.

## Why?

The local `thunderbird-accounts` Docker Compose setup bind-mounts `./keycloak/themes` over `/opt/keycloak/themes` in the Keycloak container. The Keycloak image build does generate the compiled `tbpro/static` theme assets, but the bind mount hid those image-built files at runtime. As a result, Keycloak emitted login HTML pointing at `static/app.css` and `static/app.js`, but the mounted theme directory did not contain those generated files.

The Vite local-stack proxy also rewrote textual Keycloak responses without being robust to compressed upstream bodies, so the proxy path needed hardening as well.

## QA Log
- Confirmed `https://localhost:3000/resources/.../login/tbpro/static/app.css` returns `HTTP 200` with a real `text/css` body after copying the generated assets.
- Confirmed Firefox can complete the local Keycloak sign-in flow successfully.
- Ran focused proxy tests.
- Ran full unit test suite: 50 files, 594 tests passed.
- Ran full suite of Playwright E2E tests on Chromium and Firefox.

## Applicable Issues
Fixes #32.
