### PR TITLE
Fix nightly browserstack test workflows

### DIFF
--- a/.github/workflows/e2e-desktop-nightly-firefox.yml
+++ b/.github/workflows/e2e-desktop-nightly-firefox.yml
@@ -22,4 +22,9 @@ jobs:
       browserstack_build_name: 'Nightly Webmail E2E Tests (Desktop Firefox): BUILD_INFO'
       test_step_name: Prod E2E Tests on Desktop Firefox
       npm_script: e2e:browserstack:desktop:firefox
-    secrets: inherit
+    secrets:
+      E2E_ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      E2E_ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      E2E_PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/e2e-desktop-nightly-safari.yml
+++ b/.github/workflows/e2e-desktop-nightly-safari.yml
@@ -22,4 +22,9 @@ jobs:
       browserstack_build_name: 'Nightly Webmail E2E Tests (Desktop Safari): BUILD_INFO'
       test_step_name: Prod E2E Tests on Desktop Safari
       npm_script: e2e:browserstack:desktop:safari
-    secrets: inherit
+    secrets:
+      E2E_ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      E2E_ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      E2E_PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/e2e-mobile-nightly-android.yml
+++ b/.github/workflows/e2e-mobile-nightly-android.yml
@@ -22,4 +22,9 @@ jobs:
       browserstack_build_name: 'Nightly Webmail E2E Tests (Android Chrome): BUILD_INFO'
       test_step_name: Prod E2E Tests on Android Chrome
       npm_script: e2e:browserstack:mobile:android:chrome
-    secrets: inherit
+    secrets:
+      E2E_ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      E2E_ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      E2E_PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/e2e-nightly-common.yml
+++ b/.github/workflows/e2e-nightly-common.yml
@@ -15,6 +15,17 @@ on:
       npm_script:
         required: true
         type: string
+    secrets:
+      E2E_ACCTS_OIDC_EMAIL:
+        required: true
+      E2E_ACCTS_OIDC_PWORD:
+        required: true
+      E2E_PRIMARY_THUNDERMAIL_EMAIL:
+        required: true
+      BROWSERSTACK_USERNAME:
+        required: true
+      BROWSERSTACK_ACCESS_KEY:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-nightly-common.yml
+++ b/.github/workflows/e2e-nightly-common.yml
@@ -35,7 +35,7 @@ jobs:
     name: ${{ inputs.job_name }}
     runs-on: ubuntu-latest
     environment:
-      name: production
+      name: prod
       deployment: false
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}

--- a/.github/workflows/e2e-nightly-desktop-chrome.yml
+++ b/.github/workflows/e2e-nightly-desktop-chrome.yml
@@ -22,4 +22,9 @@ jobs:
       browserstack_build_name: 'Nightly Webmail E2E Tests (Desktop Chromium): BUILD_INFO'
       test_step_name: Prod E2E Tests on Desktop Chromium
       npm_script: e2e:browserstack:desktop:chrome
-    secrets: inherit
+    secrets:
+      E2E_ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      E2E_ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      E2E_PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
## What changed?
Added explicit required secrets to the reusable workflow instead of relying on secrets: inherit. Updated each platform workflow to pass the required secrets explicitly.

## Why?
The github action workflows for the new nightly E2E tests that run in BrowserStack are failing.

Why it failed: GitHub reusable workflows have a secret boundary, and environment secrets are especially sharp here. GitHub’s docs say inherited secrets can work, but also warn that environment secrets cannot be passed from the caller via workflow_call because workflow_call does not support environment at the caller boundary. That likely left BROWSERSTACK_USERNAME empty when the BrowserStack setup action ran. See GitHub’s reusable workflow docs: [Using inputs and secrets](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow).

## Limitations and Notes
Patch by Codex AI.

## Applicable Issues
Fixes #72.
