### PR TITLE
Show recipient in Sent and Drafts message list

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -375,6 +375,23 @@ function onAvatarError(fromText) {
   failedAvatarDomains.value = new Set([...failedAvatarDomains.value, domain]);
 }
 
+/** Sent lists the people you wrote to, not yourself (Fixes #98). */
+const listShowsRecipients = computed(
+  () => mailStore.currentFolder?.role === 'sent',
+);
+
+function rowCorrespondent(row) {
+  return listShowsRecipients.value ? row?.to_text : row?.from_text;
+}
+
+function correspondentLabel(row) {
+  const text = rowCorrespondent(row);
+  if (!text) {
+    return listShowsRecipients.value ? '(no recipient)' : '(no sender)';
+  }
+  return shortFrom(text);
+}
+
 const allLoadedSelected = computed(() => {
   const loadedIds = [];
   for (const row of selectAllTargetMessages.value) {
@@ -683,24 +700,24 @@ function normalizeFilterText(value) {
               </div>
               <div
                 class="msg-list__avatar"
-                :style="senderAvatar(visibleMessages[v.index].from_text).style"
+                :style="senderAvatar(rowCorrespondent(visibleMessages[v.index])).style"
                 aria-hidden="true"
               >
                 <img
-                  v-if="senderAvatar(visibleMessages[v.index].from_text).imageUrl"
+                  v-if="senderAvatar(rowCorrespondent(visibleMessages[v.index])).imageUrl"
                   class="msg-list__avatar-image"
-                  :src="senderAvatar(visibleMessages[v.index].from_text).imageUrl"
+                  :src="senderAvatar(rowCorrespondent(visibleMessages[v.index])).imageUrl"
                   alt=""
                   loading="lazy"
                   decoding="async"
                   referrerpolicy="no-referrer"
-                  @error="onAvatarError(visibleMessages[v.index].from_text)"
+                  @error="onAvatarError(rowCorrespondent(visibleMessages[v.index]))"
                 />
-                <span>{{ senderAvatar(visibleMessages[v.index].from_text).initials }}</span>
+                <span>{{ senderAvatar(rowCorrespondent(visibleMessages[v.index])).initials }}</span>
               </div>
               <div class="msg-list__content">
                 <div class="msg-list__summary">
-                  <span class="msg-list__from">{{ shortFrom(visibleMessages[v.index].from_text) }}</span>
+                  <span class="msg-list__from">{{ correspondentLabel(visibleMessages[v.index]) }}</span>
                   <span class="msg-list__subject">{{ visibleMessages[v.index].subject || '(no subject)' }}</span>
                   <span class="msg-list__icons">
                     <Star v-if="Number(visibleMessages[v.index].is_flagged) === 1" :size="13" :stroke-width="2" class="msg-list__star" />

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -375,10 +375,11 @@ function onAvatarError(fromText) {
   failedAvatarDomains.value = new Set([...failedAvatarDomains.value, domain]);
 }
 
-/** Sent lists the people you wrote to, not yourself (Fixes #98). */
-const listShowsRecipients = computed(
-  () => mailStore.currentFolder?.role === 'sent',
-);
+/** Sent and Drafts list the people you wrote to, not yourself (Fixes #98). */
+const listShowsRecipients = computed(() => {
+  const role = mailStore.currentFolder?.role;
+  return role === 'sent' || role === 'drafts';
+});
 
 function rowCorrespondent(row) {
   return listShowsRecipients.value ? row?.to_text : row?.from_text;

--- a/tests/unit/components/message-list-sent-display.test.ts
+++ b/tests/unit/components/message-list-sent-display.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 
 /**
- * Sent-folder list rows show the recipient, not the sender (issue #98).
- * Inbox and other folders keep showing the sender.
+ * Sent- and Drafts-folder list rows show the recipient, not the sender
+ * (issue #98). Inbox and other folders keep showing the sender.
  */
 
 import {
@@ -89,7 +89,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('MessageList Sent correspondent column (issue #98)', () => {
+describe('MessageList outbox correspondent column (issue #98)', () => {
   it('shows the sender in Inbox', async () => {
     const { wrapper } = mountList();
     await nextTick();
@@ -101,6 +101,16 @@ describe('MessageList Sent correspondent column (issue #98)', () => {
   it('shows the recipient in Sent', async () => {
     const { wrapper } = mountList({
       folder: makeFolder(2, { name: 'Sent', role: 'sent' }),
+    });
+    await nextTick();
+
+    expect(wrapper.find('.msg-list__from').text()).toBe('Alice');
+    wrapper.unmount();
+  });
+
+  it('shows the recipient in Drafts', async () => {
+    const { wrapper } = mountList({
+      folder: makeFolder(3, { name: 'Drafts', role: 'drafts' }),
     });
     await nextTick();
 

--- a/tests/unit/components/message-list-sent-display.test.ts
+++ b/tests/unit/components/message-list-sent-display.test.ts
@@ -71,7 +71,7 @@ function makeRow(id, overrides = {}) {
   } as any;
 }
 
-function mountList({ folder, rows = [makeRow(1)] } = {}) {
+function mountList({ folder, rows = [makeRow(1)] }: { folder?: any; rows?: any[] } = {}) {
   const resolvedFolder = folder ?? makeFolder(1, { name: 'Inbox' });
   const mailStore = useMailStore();
   mailStore.folders = [resolvedFolder];

--- a/tests/unit/components/message-list-sent-display.test.ts
+++ b/tests/unit/components/message-list-sent-display.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+
+/**
+ * Sent-folder list rows show the recipient, not the sender (issue #98).
+ * Inbox and other folders keep showing the sender.
+ */
+
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { computed, nextTick } from 'vue';
+
+vi.mock('../../../src/services/auth', () => ({
+  initOidc: async () => null,
+  getOidc: () => null,
+}));
+
+vi.mock('@tanstack/vue-virtual', () => ({
+  useVirtualizer: (optionsRef) => computed(() => ({
+    getTotalSize: () => Number(optionsRef.value.count ?? 0) * 64,
+    getVirtualItems: () => {
+      const total = Number(optionsRef.value.count ?? 0);
+      return Array.from({ length: total }, (_, index) => ({
+        index,
+        key: optionsRef.value.getItemKey?.(index) ?? index,
+        start: index * 64,
+        size: 64,
+      }));
+    },
+    scrollToIndex: () => {},
+    measure: () => {},
+  })),
+}));
+
+import MessageList from '../../../src/components/MessageList.vue';
+import { useMailStore } from '../../../src/stores/mail-store';
+
+function makeFolder(id, overrides = {}) {
+  return {
+    id,
+    account_id: 1,
+    remote_id: `mb-${id}`,
+    name: `Folder ${id}`,
+    role: id === 1 ? 'inbox' : null,
+    sort_order: 0,
+    parent_id: null,
+    is_deleted: 0,
+    total_emails: 0,
+    unread_emails: 0,
+    may_add_items: null,
+    may_remove_items: null,
+    ...overrides,
+  } as any;
+}
+
+function makeRow(id, overrides = {}) {
+  return {
+    id,
+    remote_id: `e-${id}`,
+    from_text: 'Me <me@example.com>',
+    to_text: 'Alice <alice@example.com>',
+    subject: `Subject ${id}`,
+    preview: 'preview',
+    received_at: 1_700_000_000_000 + id,
+    is_seen: 1,
+    is_flagged: 0,
+    has_attachment: 0,
+    ...overrides,
+  } as any;
+}
+
+function mountList({ folder, rows = [makeRow(1)] } = {}) {
+  const resolvedFolder = folder ?? makeFolder(1, { name: 'Inbox' });
+  const mailStore = useMailStore();
+  mailStore.folders = [resolvedFolder];
+  mailStore.currentFolderId = resolvedFolder.id;
+  mailStore.messages = rows;
+  mailStore.totalForFolder = rows.length;
+  return { mailStore, wrapper: mount(MessageList) };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MessageList Sent correspondent column (issue #98)', () => {
+  it('shows the sender in Inbox', async () => {
+    const { wrapper } = mountList();
+    await nextTick();
+
+    expect(wrapper.find('.msg-list__from').text()).toBe('Me');
+    wrapper.unmount();
+  });
+
+  it('shows the recipient in Sent', async () => {
+    const { wrapper } = mountList({
+      folder: makeFolder(2, { name: 'Sent', role: 'sent' }),
+    });
+    await nextTick();
+
+    expect(wrapper.find('.msg-list__from').text()).toBe('Alice');
+    wrapper.unmount();
+  });
+
+  it('labels an empty To line as no recipient in Sent', async () => {
+    const { wrapper } = mountList({
+      folder: makeFolder(2, { name: 'Sent', role: 'sent' }),
+      rows: [makeRow(1, { to_text: null })],
+    });
+    await nextTick();
+
+    expect(wrapper.find('.msg-list__from').text()).toBe('(no recipient)');
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
Changes display in Sent and Drafts Folders to display the recipient, rather than the sender. (Fixes #98 )
## Test plan
- unit tests in message-list-sent-display.test.ts

Made with [Cursor](https://cursor.com)