### PR TITLE
Hide the staff gear below 700px so it cannot widen the top bar

### DIFF
--- a/src/features/kanban/StaffGearButton.vue
+++ b/src/features/kanban/StaffGearButton.vue
@@ -73,7 +73,7 @@ function onFirstUnlock() {
 
 <template>
   <button
-    class="quick-filter__action"
+    class="quick-filter__action staff-gear"
     type="button"
     aria-label="Staff settings"
     title="Staff settings"
@@ -91,3 +91,15 @@ function onFirstUnlock() {
   <FireworksOverlay v-if="celebrating" @done="celebrating = false" />
   <CelebrationVolume v-if="celebrating || soundPlaying" />
 </template>
+
+<style scoped>
+/* The top bar's end cluster only has room for a fifth 36px action from
+   about 670px up: with the gear present the two-pane bar (640–669px) and
+   the single-column bar below ~380px overflow the shell. The board needs
+   far more width than that, so the gear stays out of narrow layouts. */
+@media (max-width: 699px) {
+  .staff-gear {
+    display: none;
+  }
+}
+</style>

--- a/tests/e2e/kanban.spec.js
+++ b/tests/e2e/kanban.spec.js
@@ -12,11 +12,12 @@ import {
   resetSharedSession,
   test,
 } from './helpers/shared-session.js';
+import { loginViaOidc } from './helpers/oidc-login.js';
 import {
   localStackEnabled,
   skipLocalStackMessage,
 } from './helpers/stack-env.js';
-import { waitForFolderTreeReady, waitForPendingMutations } from './helpers/ui.js';
+import { waitForFolderTreeReady, waitForInboxReady, waitForPendingMutations } from './helpers/ui.js';
 
 /**
  * Staff kanban feature flag — Verified Consistency triple for the two
@@ -105,6 +106,41 @@ async function readFolderCacheByName(page, name) {
 function column(page, label) {
   return page.locator(`[data-kanban-column="${label}"]`);
 }
+
+async function shellOverflow(page) {
+  return page.locator('.shell').evaluate((shell) => shell.scrollWidth - shell.clientWidth);
+}
+
+test.describe('Staff gear in narrow layouts', () => {
+  // The e2e account is staff, so the gear is in every layout's top bar.
+  // Below 700px the bar has no room for it: it must disappear rather than
+  // widen the shell (sidebar-layout.spec.js measures the same shell at
+  // 640px and 340px without knowing about the gear).
+  test('the gear never widens the top bar: hidden below 700px, present above', async ({ page }) => {
+    await page.setViewportSize({ width: 1000, height: 852 });
+    await page.addInitScript(() => {
+      window.localStorage.setItem('stormbox.welcomeModalDismissed.v1', '1');
+    });
+    await loginViaOidc(page);
+    await waitForInboxReady(page);
+
+    const gear = page.locator('[data-staff-gear]');
+    await expect(gear).toBeVisible();
+    expect(await shellOverflow(page)).toBeLessThanOrEqual(0);
+
+    for (const width of [699, 640, 340]) {
+      await page.setViewportSize({ width, height: 852 });
+      await expect(gear).toBeHidden();
+      await expect.poll(() => shellOverflow(page), { message: `shell overflow at ${width}px` })
+        .toBeLessThanOrEqual(0);
+    }
+
+    await page.setViewportSize({ width: 700, height: 852 });
+    await expect(gear).toBeVisible();
+    await expect.poll(() => shellOverflow(page), { message: 'shell overflow at 700px' })
+      .toBeLessThanOrEqual(0);
+  });
+});
 
 test.describe('Kanban feature flag e2e', () => {
   test.beforeEach(async ({ sharedPage }) => {

--- a/tests/unit/features/kanban/staff-gear.test.ts
+++ b/tests/unit/features/kanban/staff-gear.test.ts
@@ -1,5 +1,8 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import {
   afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest';
@@ -171,6 +174,16 @@ describe('staff gear in App', () => {
     expect(children[gearIndex - 1]?.classList.contains('theme-toggle')).toBe(true);
     expect(wrapper.find('.msg-list').exists()).toBe(true);
     expect(wrapper.find('[data-testid="kanban-board"]').exists()).toBe(false);
+  });
+
+  it('stays out of the top bar below 700px, where a fifth action overflows the shell', () => {
+    // The bar's end cluster fits five 36px actions only from ~670px up; the
+    // sidebar-layout e2e pins the 640px and 340px layouts against overflow.
+    const source = readFileSync(resolve(process.cwd(), 'src/features/kanban/StaffGearButton.vue'), 'utf8');
+    expect(source).toMatch(/class="quick-filter__action staff-gear"/);
+    expect(source).toMatch(
+      /@media\s*\(max-width:\s*699px\)\s*\{[\s\S]*?\.staff-gear\s*\{[\s\S]*?display:\s*none;/,
+    );
   });
 
   it('gear opens a code dialog; a wrong code is rejected and changes nothing', async () => {


### PR DESCRIPTION
## Summary
- Fixes the 4 `sidebar-layout.spec.js` e2e failures on `main` after #124 (run [33664272272](https://github.com/thunderbird/stormbox/actions/runs/33664272272)), which blocked the deploy.
- Cause: the e2e account is on a staff domain, so the new gear joined the top bar's end cluster. Five 36px actions don't fit there below ~670px, so the shell overflowed at 640px (two-pane) and 340px (single-column).
- Fix: the gear hides below 700px (scoped CSS in `StaffGearButton.vue`; the board is unusable that narrow anyway). Nothing changes for non-staff.

## Test plan
- [x] New e2e in `kanban.spec.js` measures shell overflow with the gear at 1000 / 700 / 699 / 640 / 340px
- [x] Source test pins the media query in `staff-gear.test.ts`
- [x] `sidebar-layout.spec.js` + `kanban.spec.js` green locally in chromium and firefox
- [x] lint / typecheck clean